### PR TITLE
Add Create-powered mana pool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,8 @@ repositories {
 
     // If you have mod jar dependencies in ./libs, you can declare them as a repository like so.
     // See https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:flat_dir_resolver
+    maven { url 'https://maven.blamejared.com' }
+    maven { url 'https://maven.tterrag.com' }
     // flatDir {
     //     dir 'libs'
     // }
@@ -130,6 +132,10 @@ dependencies {
     // If the group id is "net.minecraft" and the artifact id is one of ["client", "server", "joined"],
     // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
+
+    implementation fg.deobf("vazkii.botania:Botania:1.20.1-448-FORGE")
+    // Match the Create version used in the user's modpack
+    implementation fg.deobf("com.simibubi.create:create-1.20.1:0.5.1-j")
 
     // Example mod dependency with JEI - using fg.deobf() ensures the dependency is remapped to your development mappings
     // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime

--- a/src/main/java/org/yolka/mechanical_botania/Mechanical_botania.java
+++ b/src/main/java/org/yolka/mechanical_botania/Mechanical_botania.java
@@ -27,6 +27,9 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
+import org.yolka.mechanical_botania.block.RotationalManaPoolBlock;
+import org.yolka.mechanical_botania.blockentity.RotationalManaPoolBlockEntity;
+import org.yolka.mechanical_botania.registry.ModBlockEntities;
 import org.slf4j.Logger;
 
 // The value here should match an entry in the META-INF/mods.toml file
@@ -49,6 +52,12 @@ public class Mechanical_botania {
     // Creates a new BlockItem with the id "mechanical_botania:example_block", combining the namespace and path
     public static final RegistryObject<Item> EXAMPLE_BLOCK_ITEM = ITEMS.register("example_block", () -> new BlockItem(EXAMPLE_BLOCK.get(), new Item.Properties()));
 
+    // Block that converts Create rotation into mana
+    public static final RegistryObject<Block> ROTATIONAL_MANA_POOL = BLOCKS.register("rotational_mana_pool",
+            () -> new RotationalManaPoolBlock(BlockBehaviour.Properties.of().strength(2.0F)));
+    public static final RegistryObject<Item> ROTATIONAL_MANA_POOL_ITEM = ITEMS.register("rotational_mana_pool",
+            () -> new BlockItem(ROTATIONAL_MANA_POOL.get(), new Item.Properties()));
+
     // Creates a new food item with the id "mechanical_botania:example_id", nutrition 1 and saturation 2
     public static final RegistryObject<Item> EXAMPLE_ITEM = ITEMS.register("example_item", () -> new Item(new Item.Properties().food(new FoodProperties.Builder().alwaysEat().nutrition(1).saturationMod(2f).build())));
 
@@ -63,12 +72,11 @@ public class Mechanical_botania {
         // Register the commonSetup method for modloading
         modEventBus.addListener(this::commonSetup);
 
-        // Register the Deferred Register to the mod event bus so blocks get registered
+        // Register deferred registers
         BLOCKS.register(modEventBus);
-        // Register the Deferred Register to the mod event bus so items get registered
         ITEMS.register(modEventBus);
-        // Register the Deferred Register to the mod event bus so tabs get registered
         CREATIVE_MODE_TABS.register(modEventBus);
+        ModBlockEntities.BLOCK_ENTITIES.register(modEventBus);
 
         // Register ourselves for server and other game events we are interested in
         MinecraftForge.EVENT_BUS.register(this);
@@ -94,7 +102,10 @@ public class Mechanical_botania {
 
     // Add the example block item to the building blocks tab
     private void addCreative(BuildCreativeModeTabContentsEvent event) {
-        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) event.accept(EXAMPLE_BLOCK_ITEM);
+        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) {
+            event.accept(EXAMPLE_BLOCK_ITEM);
+            event.accept(ROTATIONAL_MANA_POOL_ITEM);
+        }
     }
 
     // You can use SubscribeEvent and let the Event Bus discover methods to call

--- a/src/main/java/org/yolka/mechanical_botania/block/RotationalManaPoolBlock.java
+++ b/src/main/java/org/yolka/mechanical_botania/block/RotationalManaPoolBlock.java
@@ -1,0 +1,22 @@
+package org.yolka.mechanical_botania.block;
+
+import com.simibubi.create.content.kinetics.base.RotatedPillarKineticBlock;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.yolka.mechanical_botania.blockentity.RotationalManaPoolBlockEntity;
+
+import javax.annotation.Nullable;
+
+public class RotationalManaPoolBlock extends RotatedPillarKineticBlock implements EntityBlock {
+    public RotationalManaPoolBlock(Properties properties) {
+        super(properties);
+    }
+
+    @Nullable
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new RotationalManaPoolBlockEntity(pos, state);
+    }
+}

--- a/src/main/java/org/yolka/mechanical_botania/blockentity/RotationalManaPoolBlockEntity.java
+++ b/src/main/java/org/yolka/mechanical_botania/blockentity/RotationalManaPoolBlockEntity.java
@@ -1,0 +1,103 @@
+package org.yolka.mechanical_botania.blockentity;
+
+import com.simibubi.create.content.kinetics.simpleRelays.SimpleKineticBlockEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.yolka.mechanical_botania.registry.ModBlockEntities;
+import vazkii.botania.api.mana.ManaPool;
+
+import java.util.Optional;
+
+public class RotationalManaPoolBlockEntity extends SimpleKineticBlockEntity implements ManaPool {
+    private static final int MAX_MANA = 100000;
+    private int mana = 0;
+    private Optional<DyeColor> color = Optional.empty();
+
+    public RotationalManaPoolBlockEntity(BlockPos pos, BlockState state) {
+        super(ModBlockEntities.ROTATIONAL_MANA_POOL.get(), pos, state);
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        if (level != null && !level.isClientSide) {
+            float speed = getSpeed();
+            if (speed != 0 && mana < MAX_MANA) {
+                mana = Math.min(MAX_MANA, mana + (int) Math.abs(speed));
+                setChanged();
+            }
+        }
+    }
+
+    @Override
+    public void saveAdditional(CompoundTag tag) {
+        super.saveAdditional(tag);
+        tag.putInt("Mana", mana);
+        color.ifPresent(c -> tag.putInt("Color", c.getId()));
+    }
+
+    @Override
+    public void load(CompoundTag tag) {
+        super.load(tag);
+        mana = tag.getInt("Mana");
+        if (tag.contains("Color")) {
+            color = Optional.of(DyeColor.byId(tag.getInt("Color")));
+        } else {
+            color = Optional.empty();
+        }
+    }
+
+    // ManaPool implementation
+    @Override
+    public Level getManaReceiverLevel() {
+        return level;
+    }
+
+    @Override
+    public BlockPos getManaReceiverPos() {
+        return worldPosition;
+    }
+
+    @Override
+    public int getCurrentMana() {
+        return mana;
+    }
+
+    @Override
+    public boolean isFull() {
+        return mana >= MAX_MANA;
+    }
+
+    @Override
+    public void receiveMana(int mana) {
+        this.mana = Math.min(MAX_MANA, this.mana + mana);
+    }
+
+    @Override
+    public boolean canReceiveManaFromBursts() {
+        return true;
+    }
+
+    @Override
+    public boolean isOutputtingPower() {
+        return true;
+    }
+
+    @Override
+    public int getMaxMana() {
+        return MAX_MANA;
+    }
+
+    @Override
+    public Optional<DyeColor> getColor() {
+        return color;
+    }
+
+    @Override
+    public void setColor(Optional<DyeColor> color) {
+        this.color = color;
+    }
+}

--- a/src/main/java/org/yolka/mechanical_botania/registry/ModBlockEntities.java
+++ b/src/main/java/org/yolka/mechanical_botania/registry/ModBlockEntities.java
@@ -1,0 +1,18 @@
+package org.yolka.mechanical_botania.registry;
+
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import org.yolka.mechanical_botania.Mechanical_botania;
+import org.yolka.mechanical_botania.blockentity.RotationalManaPoolBlockEntity;
+
+public class ModBlockEntities {
+    public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES =
+            DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, Mechanical_botania.MODID);
+
+    public static final RegistryObject<BlockEntityType<RotationalManaPoolBlockEntity>> ROTATIONAL_MANA_POOL =
+            BLOCK_ENTITIES.register("rotational_mana_pool",
+                    () -> BlockEntityType.Builder.of(RotationalManaPoolBlockEntity::new,
+                            Mechanical_botania.ROTATIONAL_MANA_POOL.get()).build(null));
+}


### PR DESCRIPTION
## Summary
- register a new rotational mana pool block and block entity
- integrate Create and Botania dependencies
- expose the new item in the creative tab
- bump Create dependency to 0.5.1.j per user setup

## Testing
- `gradle build -x test` *(fails: Create dependency not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512bf20b2483209320d5eea9fb9a01